### PR TITLE
Adding support to only log slow queries

### DIFF
--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -238,8 +238,9 @@ class Database(local, NodeClassRegistry):
                                          retry_on_session_expire=False)
             raise
 
-        if os.environ.get('NEOMODEL_CYPHER_DEBUG', False):
-            logger.debug("query: " + query + "\nparams: " + repr(params) + "\ntook: {:.2g}s\n".format(end - start))
+        tte = (end - start)
+        if os.environ.get('NEOMODEL_CYPHER_DEBUG', False) and tte > float(os.environ.get('NEOMODEL_SLOW_QUERIES', 0)):
+            logger.debug("query: " + query + "\nparams: " + repr(params) + "\ntook: {:.2g}s\n".format(tte))
 
         return results, meta
         


### PR DESCRIPTION
This change adds support so that logging within ```neomodel.utils.py`` only occurs if the query time (``tte``) exceeds a threshold set by a new environmental setting. If that setting is not set then it acts like before I.E as if it were set to 0 and records every query.

Example usage: Setting ```os.environ["NEOMODEL_SLOW_QUERIES"] = "0.09"``` will cause only queries that take longer than 0.09 seconds to run to be logged. If NEOMODEL_SLOW_QUERIES is not set, then it is treated as being 0 and therefore the logging acts as before